### PR TITLE
Use correct plural

### DIFF
--- a/src/classes/Bot.ts
+++ b/src/classes/Bot.ts
@@ -104,10 +104,10 @@ class Bot {
 	}
 
 	public setStatus() {
-		const plural = this.onlineCount !== 1;
+		const plural = this.onlineCount - 1 !== 1;
 
 		if (this.discord.isReady()) {
-			this.discord.user.setActivity(`${this.onlineCount} online player${plural ? "s" : ""}`, {
+			this.discord.user.setActivity(`${this.onlineCount - 1} online player${plural ? "s" : ""}`, {
 				type: ActivityType.Watching,
 			});
 		}

--- a/src/classes/Bot.ts
+++ b/src/classes/Bot.ts
@@ -104,7 +104,7 @@ class Bot {
 	}
 
 	public setStatus() {
-		const plural = this.onlineCount - 1 !== 1;
+		const plural = this.onlineCount !== 1;
 
 		if (this.discord.isReady()) {
 			this.discord.user.setActivity(`${this.onlineCount} online player${plural ? "s" : ""}`, {


### PR DESCRIPTION
Unless your intention was to display the amount of players `-1`, the plural displays incorrectly in the Discord status.
