### PR TITLE
Fix limbo warping

### DIFF
--- a/src/@types/event.d.ts
+++ b/src/@types/event.d.ts
@@ -1,6 +1,6 @@
 declare interface Event {
     name:
-        | keyof typeof import('@util/regex').default
+        | keyof typeof import('@events/regex').default
         | keyof import('mineflayer').BotEvents
         | keyof import('discord.js').ClientEvents;
     runOnce: boolean;

--- a/src/events/mineflayer/chat/join-limbo.ts
+++ b/src/events/mineflayer/chat/join-limbo.ts
@@ -3,5 +3,6 @@ export default {
     runOnce: false,
     run: (bot) => {
         bot.logger.info('Bot has joined Limbo!');
+        bot.limboTries = 0;
     },
 } as Event;

--- a/src/events/mineflayer/chat/lobby-join.ts
+++ b/src/events/mineflayer/chat/lobby-join.ts
@@ -2,7 +2,6 @@ export default {
     name: 'chat:lobbyJoin',
     runOnce: false,
     run: (bot) => {
-        bot.logger.warn('Detected that the bot is not in Limbo, sending to limbo.');
         bot.sendToLimbo();
     },
 } as Event;

--- a/src/events/regex.ts
+++ b/src/events/regex.ts
@@ -59,7 +59,7 @@ export default {
     'chat:joinLimbo': /^You were spawned in Limbo.$/,
 
     /**
-     * When the bot detects its not in Limbo
+     * When the bot detects it's not in Limbo
      */
     'chat:lobbyJoin':
         /^(?:\s>>>\s)?\[.*]\s[\w]{2,17} (?:joined|spooked into|slid into) the lobby!(?:\s<<<)?$/,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,8 +16,8 @@
         "skipLibCheck": true,
         "isolatedModules": true,
         "paths": {
-            "@classes/*": ["./src/classes/*"], 
-            "@events/*": ["./src/events/*"], 
+            "@classes/*": ["./src/classes/*"],
+            "@events/*": ["./src/events/*"],
             "@util/*": ["./src/util/*"]
         }
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
         "skipLibCheck": true,
         "isolatedModules": true,
         "paths": {
-            "@classes/*": ["./src/classes/*"],
+            "@classes/*": ["./src/classes/*"], 
+            "@events/*": ["./src/events/*"], 
             "@util/*": ["./src/util/*"]
         }
     }


### PR DESCRIPTION
Adds fallback support for `disconnect.spam` if illegal characters fail to send the bot to limbo